### PR TITLE
removed a typo from a link to book github repo

### DIFF
--- a/sections/perl_community.pod
+++ b/sections/perl_community.pod
@@ -87,7 +87,7 @@ X<Gitpan>
 
 Many Perl hackers use Github (U<http://github.com/>) to host their
 projectsN<...  including the drafts of this book at
-U<http://github.com/chromatic/modern_perl_book/>>.  One particularly notable
+U<http://github.com/chromatic/modern_perl_book/>.  One particularly notable
 page on Github is Gitpan, which hosts Git repositories chronicling the complete
 history of every distribution on the CPAN.  See U<http://github.com/gitpan/>.
 


### PR DESCRIPTION
There was an extra > in there.
