### PR TITLE
Fat comma typo

### DIFF
--- a/sections/functions.pod
+++ b/sections/functions.pod
@@ -229,10 +229,10 @@ hash as an argument produces a list of key/value pairs:
     }
 
     my %pet_names_and_types = (
-        Lucky   = > 'dog',
-        Rodney  = > 'dog',
-        Tuxedo  = > 'cat',
-        Petunia = > 'cat',
+        Lucky   => 'dog',
+        Rodney  => 'dog',
+        Tuxedo  => 'cat',
+        Petunia => 'cat',
     );
 
     show_pets( %pet_names_and_types );
@@ -264,10 +264,10 @@ remove it from the end of C<@_>):
     }
 
     my %pet_names_and_types = (
-        Lucky   = > 'dog',
-        Rodney  = > 'dog',
-        Tuxedo  = > 'cat',
-        Petunia = > 'cat',
+        Lucky   => 'dog',
+        Rodney  => 'dog',
+        Tuxedo  => 'cat',
+        Petunia => 'cat',
     );
 
     show_pets_by_type( 'dog',   %pet_names_and_types );


### PR DESCRIPTION
There was a basic syntax error in some of your examples. This fixes that.
