### PR TITLE
small patch on Moose chapter: default without subref

### DIFF
--- a/sections/moose.pod
+++ b/sections/moose.pod
@@ -539,7 +539,7 @@ explicitly mark that it does the role:
     has 'name',        is => 'ro', isa => 'Str';
     has 'diet',        is => 'rw', isa => 'Str';
     has 'birth_year',  is => 'ro', isa => 'Int',
-                       default => (localtime)[5] + 1900;
+                       default => sub { (localtime)[5] + 1900 };
 
     B<with 'LivingBeing';>
 


### PR DESCRIPTION
Hi chromatic!

I found a tiny issue in one of the Moose examples, where a "default" call is not wrapped as a subref. So here's the patch :-)

Thanks for such an awesome book. I'm teaching a modern Perl summer course to undergrads this week, and recommending it to all students.
