### PR TITLE
ePub formatting issue fixed for compatibility with iBooks

### DIFF
--- a/build/tools/build_epub.pl
+++ b/build/tools/build_epub.pl
@@ -273,7 +273,7 @@ sub generate_ebook
 
         $epub->copy_xhtml('./build/xhtml/' . $name,
                           'text/' . $name,
-                          linear => 'no');
+                          linear => 'yes');
     }
 
     # Add Pod headings to table of contents.


### PR DESCRIPTION
Hi chromatic,

I've fixed an issue with the ePub display in iBooks on the iPad / iPhone.

The chapters were added with the attribute "linear = no" which was preventing pagination - this had the effect of making it impossible to read across chapter boundaries or select headings from the ToC.

Cheers,

JJ
