### PR TITLE
Fixed issue #160 - "The Ternary Conditional Operator" example confuses the reader (Control Flow section)

### DIFF
--- a/sections/control_flow.pod
+++ b/sections/control_flow.pod
@@ -238,7 +238,7 @@ different results:
 
 =begin programlisting
 
-    my $time_suffix = after_noon($time) ? 'morning' : 'afternoon';
+    my $time_suffix = after_noon($time) ? 'afternoon' : 'morning';
 
 =end programlisting
 


### PR DESCRIPTION
Fixed ternary ordering in "The Ternary Conditional Operator" (Chapter 3, Control Flow Section)
