### PR TITLE
Minor typo fixes.

### DIFF
--- a/sections/arrays.pod
+++ b/sections/arrays.pod
@@ -347,7 +347,7 @@ normal Perl 5 function, they will flatten into a single list:
 
 =end programlisting
 
-Within the function, C<@_> will contain seven elements, not two, becaues list
+Within the function, C<@_> will contain seven elements, not two, because list
 assignment to arrays is I<greedy>. An array will consume as many elements from
 the list as possible. After the assignment, C<@cats> will contain I<every>
 argument passed to the function. C<@dogs> will be empty.

--- a/sections/code_generation.pod
+++ b/sections/code_generation.pod
@@ -144,7 +144,7 @@ X<sigils; C<*>>
 X<typeglobs>
 
 The odd syntax of an asteriskN<Think of it as a I<typeglob sigil>, where a
-I<typeglob> is Perl jargon for "symbol table".> deferencing a hash refers to a
+I<typeglob> is Perl jargon for "symbol table".> dereferencing a hash refers to a
 symbol in the current I<symbol table>, which is the portion of the current
 namespace which contains globally-accessible symbols such as package globals,
 functions, and methods. Assigning a reference to a symbol table entry installs

--- a/sections/cpan.pod
+++ b/sections/cpan.pod
@@ -50,7 +50,7 @@ distributions. These include:
 
 =item Standards for automated CPAN installers.
 
-=item Standards for metadata to describe what what each distribution provides
+=item Standards for metadata to describe what each distribution provides
 and expects.
 
 =item Standards for documentation and licensing.

--- a/sections/files.pod
+++ b/sections/files.pod
@@ -466,7 +466,7 @@ builtin.
 
 =head3 Manipulating Paths
 
-Perl 5 offers a Unixy view of your filesystem and will will interpret
+Perl 5 offers a Unixy view of your filesystem and will interpret
 Unix-style paths appropriately for your operating system and filesystem.  In
 other words, if you're using Microsoft Windows, you can use the path F<C:/My
 Documents/Robots/Bender/> just as easily as you can use the path F<C:\My

--- a/sections/implicit_ideas.pod
+++ b/sections/implicit_ideas.pod
@@ -63,7 +63,7 @@ arguments:
 
 =end programlisting
 
-X<C<s///>; subsitution operator>
+X<C<s///>; substitution operator>
 X<C<m//>; match operator>
 X<C<tr//>; transliteration operator>
 

--- a/sections/perl_community.pod
+++ b/sections/perl_community.pod
@@ -11,7 +11,7 @@ you're new to Perl, the Perl beginners mailing list is a friendly place to ask
 novice questions and get accurate and helpful answers. See
 U<http://learn.perl.org/faq/beginners.html>.
 
-The home of Perl development is is U<http://dev.perl.org/>, which links to
+The home of Perl development is U<http://dev.perl.org/>, which links to
 relevant resources for developing core development of Perl 5, Perl 6N<Though
 see also U<http://www.perl6.org/>>, and even Perl 1.
 

--- a/sections/regular_expressions.pod
+++ b/sections/regular_expressions.pod
@@ -876,7 +876,7 @@ zero-width positive look-behind assertion I<can> have a variable length:
 
 =end programlisting
 
-C<\K> is surprisingly useful for for certain substitutions which remove the end
+C<\K> is surprisingly useful for certain substitutions which remove the end
 of a pattern:
 
 =begin programlisting


### PR DESCRIPTION
Minor typo fixes including one in an index entry. (I was tempted by s/barbeque/barbecue/g but left it.)
Regards,
 Mark.
