### PR TITLE
Change "regexp" to "regex" to be consistent with other usage.

### DIFF
--- a/sections/regular_expressions.pod
+++ b/sections/regular_expressions.pod
@@ -71,7 +71,7 @@ match operator to use them:
 
 =end programlisting
 
-Combine multiple regexp objects into complex patterns:
+Combine multiple regex objects into complex patterns:
 
 =begin programlisting
 


### PR DESCRIPTION
You use 'regex' everywhere except this one place where you use 'regexp'. Obviously, both are valid but I think it is probably better to be consistent.
-Mark.
