### PR TITLE
Changed CPAN module links to MetaCPAN

### DIFF
--- a/sections/cpan.pod
+++ b/sections/cpan.pod
@@ -155,8 +155,8 @@ distributions in your own user directory, rather than for the system as a
 whole. This is an effective way to maintain CPAN distributions for individual
 users without affecting the system as a whole.  Installation is somewhat more
 involved than the previous two distributions, though C<App::local::lib::helper>
-can simplify the process.  See U<http://search.cpan.org/perldoc?local::lib> and
-U<http://search.cpan.org/perldoc?App::local::lib::helper> for more details.
+can simplify the process.  See U<https://metacpan.org/pod/local::lib> and
+U<https://metacpan.org/pod/App::local::lib::helper> for more details.
 
 All three projects tend to assume a Unix-like environment (such
 as a GNU/Linux distribution or even Mac OS X). Windows users, see the Padre


### PR DESCRIPTION
I've changed module links from search.cpan.org to metacpan.org - the latter provides better user experience for newcomers. 

Also, if you're OK with this transition, I think you should consider pointing to MetaCPAN by default.
