### PR TITLE
Why not use the experimental pragma?

### DIFF
--- a/sections/functions.pod
+++ b/sections/functions.pod
@@ -184,6 +184,16 @@ C<Method::Signatures> require this.)
 
 =end programlisting
 
+Better yet, you can do both at once with the C<experimental> pragma
+
+=begin programlisting
+
+    use  experimental 'signatures';
+    
+=end programlisting
+
+which is both shorter and clearer--- a win-win!
+
 With that disclaimer in place, you can now write:
 
 =begin programlisting


### PR DESCRIPTION
Now that we have the experimental pragma, is it even worth mentioning the two-line form?