### PR TITLE
Get rid of unnecessary chomp

### DIFF
--- a/sections/control_flow.pod
+++ b/sections/control_flow.pod
@@ -895,7 +895,6 @@ parser that joins lines which end with a backslash:
         if ($line =~ s{\\$}{})
         {
             $line .= <$fh>;
-            chomp $line;
             B<redo;>
         }
 


### PR DESCRIPTION
After calling redo, the first thing that happens is a chomp $line. The
chomp after reading a continuation line is unnecessary.