### PR TITLE
Change chp.regex to regex in all files

### DIFF
--- a/sections/autoload.pod
+++ b/sections/autoload.pod
@@ -54,7 +54,7 @@ the package global C<$AUTOLOAD> (here, C<main::bake_pie>):
 
 =end programlisting
 
-Extract the method name with a regular expression (L<chp.regex>):
+Extract the method name with a regular expression (L<regex>):
 
 =begin programlisting
 

--- a/sections/chapter_06.pod
+++ b/sections/chapter_06.pod
@@ -1,6 +1,6 @@
 =head0 Regular Expressions and Matching
 
-Z<chp.regex>
+Z<regex>
 
 X<regular expressions>
 X<regex>

--- a/sections/implicit_ideas.pod
+++ b/sections/implicit_ideas.pod
@@ -71,7 +71,7 @@ X<C<s///>; substitution operator>
 X<C<m//>; match operator>
 X<C<tr//>; transliteration operator>
 
-Perl's regular expression facilities (L<chp.regex>) default to C<$_> to match,
+Perl's regular expression facilities (L<regex>) default to C<$_> to match,
 substitute, and transliterate:
 
 =begin programlisting

--- a/sections/values.pod
+++ b/sections/values.pod
@@ -285,7 +285,7 @@ heard of bytes.
 
 Unicode strings and binary strings look superficially similar. Each has a
 C<length()>. Each supports standard string operations such as concatenation,
-splicing, and regular expression processing (L<chp.regex>). Any string which is
+splicing, and regular expression processing (L<regex>). Any string which is
 not purely binary data is textual data, and thus should be a sequence of
 Unicode characters.
 


### PR DESCRIPTION
build_html.pl fails to create html files with this error:

Unknown link regex

Replacing chp.regex with regex in these files corrects the problem:

   sections/autoload.pod
   sections/chapter_06.pod
   sections/implicit_ideas.pod
   sections/values.pod