### PR TITLE
fix logical error in error message

### DIFF
--- a/sections/functions.pod
+++ b/sections/functions.pod
@@ -199,8 +199,8 @@ With that disclaimer in place, you can now write:
 =begin programlisting
 
     sub greet_one {
-        die "Too many arguments for subroutine" if @_ < 1;
-        die "Too few arguments for subroutine" if @_ > 1;
+        die "Too few arguments for subroutine" if @_ < 1;
+        die "Too many arguments for subroutine" if @_ > 1;
         my $name = shift;
         say "Hello, $name!";
     }


### PR DESCRIPTION
`greet_one` single string,
so if num of args > 1 it's "Too many", otherwise it's "Too few"